### PR TITLE
Various improvements

### DIFF
--- a/config/typescript.php
+++ b/config/typescript.php
@@ -8,6 +8,15 @@ return [
         Model::class => ModelGenerator::class,
     ],
 
+    'paths' => [
+        //
+    ],
+
+    'customRules' => [
+        // \App\Rules\MyCustomRule::class => 'string',
+        // \App\Rules\MyOtherCustomRule::class => ['string', 'number'],
+    ],
+
     'output' => resource_path('js/models.d.ts'),
 
     'autoloadDev' => false,

--- a/src/Commands/TypeScriptGenerateCommand.php
+++ b/src/Commands/TypeScriptGenerateCommand.php
@@ -4,7 +4,6 @@ namespace Based\TypeScript\Commands;
 
 use Based\TypeScript\TypeScriptGenerator;
 use Illuminate\Console\Command;
-use Spatie\LaravelPackageTools\Package;
 
 class TypeScriptGenerateCommand extends Command
 {
@@ -15,7 +14,10 @@ class TypeScriptGenerateCommand extends Command
     public function handle()
     {
         $generator = new TypeScriptGenerator(
-            ...config('typescript')
+            generators: config('typescript.generators', []),
+            paths: config('typescript.paths', []),
+            output: config('typescript.output', resource_path('js/models.d.ts')),
+            autoloadDev: config('typescript.autoloadDev', false),
         );
 
         $generator->execute();

--- a/src/Contracts/Generator.php
+++ b/src/Contracts/Generator.php
@@ -2,7 +2,11 @@
 
 namespace Based\TypeScript\Contracts;
 
+use ReflectionClass;
+
 interface Generator
 {
-    public function getDefinition(): string;
+    public function generate(ReflectionClass $reflection): ?string;
+
+    public function getDefinition(): ?string;
 }

--- a/src/Definitions/TypeScriptProperty.php
+++ b/src/Definitions/TypeScriptProperty.php
@@ -12,21 +12,22 @@ class TypeScriptProperty
         public bool $optional = false,
         public bool $readonly = false,
         public bool $nullable = false
-    ) {
+    )
+    {
     }
 
     public function getTypes(): string
     {
         return collect($this->types)
-            ->when($this->nullable, fn (Collection $types) => $types->push(TypeScriptType::NULL))
+            ->when($this->nullable, fn(Collection $types) => $types->push(TypeScriptType::NULL))
             ->join(' | ', '');
     }
 
     public function __toString(): string
     {
         return collect($this->name)
-            ->when($this->readonly, fn (Collection $definition) => $definition->prepend('readonly '))
-            ->when($this->optional, fn (Collection $definition) => $definition->push('?'))
+            ->when($this->readonly, fn(Collection $definition) => $definition->prepend('readonly '))
+            ->when($this->optional, fn(Collection $definition) => $definition->push('?'))
             ->push(': ')
             ->push($this->getTypes())
             ->push(';')

--- a/src/Definitions/TypeScriptType.php
+++ b/src/Definitions/TypeScriptType.php
@@ -22,7 +22,7 @@ class TypeScriptType
     {
         $types = $method->getReturnType() instanceof ReflectionUnionType
             ? $method->getReturnType()->getTypes()
-            : (string)$method->getReturnType();
+            : (string) $method->getReturnType();
 
         return collect($types)
             ->map(function (string $type) {

--- a/src/Definitions/TypeScriptType.php
+++ b/src/Definitions/TypeScriptType.php
@@ -8,7 +8,7 @@ use ReflectionUnionType;
 class TypeScriptType
 {
     public const STRING = 'string';
-    public const NUMBER  = 'number';
+    public const NUMBER = 'number';
     public const BOOLEAN = 'boolean';
     public const ANY = 'any';
     public const NULL = 'null';
@@ -22,7 +22,7 @@ class TypeScriptType
     {
         $types = $method->getReturnType() instanceof ReflectionUnionType
             ? $method->getReturnType()->getTypes()
-            : (string) $method->getReturnType();
+            : (string)$method->getReturnType();
 
         return collect($types)
             ->map(function (string $type) {

--- a/src/Generators/AbstractGenerator.php
+++ b/src/Generators/AbstractGenerator.php
@@ -2,22 +2,27 @@
 
 namespace Based\TypeScript\Generators;
 
-use ReflectionClass;
 use Based\TypeScript\Contracts\Generator;
+use ReflectionClass;
 
 abstract class AbstractGenerator implements Generator
 {
     protected ReflectionClass $reflection;
 
-    public function generate(ReflectionClass $reflection): string
+    public function generate(ReflectionClass $reflection): ?string
     {
         $this->reflection = $reflection;
         $this->boot();
 
+        if (empty(trim($definition = $this->getDefinition()))) {
+            return "    export interface {$this->tsClassName()} {}" . PHP_EOL;
+        }
+
         return <<<TS
             export interface {$this->tsClassName()} {
-                {$this->getDefinition()}
+                $definition
             }
+
         TS;
     }
 

--- a/src/Generators/RequestGenerator.php
+++ b/src/Generators/RequestGenerator.php
@@ -1,0 +1,381 @@
+<?php
+
+namespace Based\TypeScript\Generators;
+
+use Based\TypeScript\Definitions\TypeScriptProperty;
+use Based\TypeScript\Definitions\TypeScriptType;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Types\Types;
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Validation\ClosureValidationRule;
+use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\Validator;
+use JetBrains\PhpStorm\Pure;
+use Laravel\Fortify\Rules\Password as FortifyPassword;
+
+class RequestGenerator extends AbstractGenerator
+{
+    const CONTROL_KEYS = [
+        'sometimes',
+        'prohibited',
+        'required',
+        'nullable',
+        'confirmed',
+        'same',
+    ];
+
+    protected FormRequest $request;
+
+    protected Validator $validator;
+
+    /** @var array<string, string|string[]> */
+    protected array $customRules;
+
+    public function getDefinition(): ?string
+    {
+        $rules = collect($this->validator->getRules());
+
+        if (method_exists($this->request, 'rules')) {
+            $rules = $rules->merge($this->request->rules());
+        }
+
+        if ($rules->isEmpty()) {
+            return null;
+        }
+
+        $rules = $rules
+            ->flatMap(fn(array|string $rules, string $property) => $this->parseRules($property, $rules))
+            ->filter();
+
+        if ($rules->isEmpty()) {
+            return null;
+        }
+
+        return $this->rulesToStringArray($rules)->join(PHP_EOL . '        ');
+    }
+
+    /**
+     * @throws \ReflectionException
+     */
+    protected function boot(): void
+    {
+        /** @var FormRequest $request */
+        $request = $this->reflection->newInstance();
+        $this->request = $request->setContainer(app());
+
+        $clazz = new \ReflectionClass($this->request);
+        $method = $clazz->getMethod('getValidatorInstance');
+        $method->setAccessible(true);
+
+        /** @var \Illuminate\Validation\Validator $validator */
+        $this->validator = $method->invoke($this->request);
+
+        $this->customRules = config('typescript.customRules');
+    }
+
+    /**
+     * @param array|string $rules
+     * @param string $property
+     * @return string[]|null
+     */
+    private function parseRules(string $property, array|string $rules): ?array
+    {
+        if (is_string($rules)) {
+            $rules = explode('|', $rules);
+        }
+
+        $rules = collect($rules)
+            ->values()
+            ->flatMap(fn(string|Rule $rule) => match (true) {
+                is_object($rule) => $this->parseRuleObject($property, $rule),
+                default => $this->parseRuleString($property, $rule)
+            })
+            ->except('');
+
+        if ($rules->isEmpty()) {
+            $rules['any'] = null;
+        }
+
+        if ($rules->has('prohibited')) {
+            return null;
+        }
+
+        $types = $this->getPropertyTypes($rules);
+        if (empty($types)) {
+            return null;
+        }
+
+        $isOptional = $rules->has('sometimes') || (!$rules->has('present') && !$rules->has('required'));
+        $isNullable = $rules->has('nullable');
+
+        $properties = [
+            $property => [
+                'name' => $property,
+                'types' => $types,
+                'optional' => $isOptional,
+                'nullable' => $isNullable,
+            ]
+        ];
+
+        if ($rules->has('confirmed')) {
+            $properties[$extraProperty = $rules['confirmed'] ?? "{$property}_confirmation"] = [
+                'name' => $extraProperty,
+                'types' => $types,
+                'optional' => $isOptional,
+                'nullable' => $isNullable,
+            ];
+        }
+
+        return $properties;
+    }
+
+    /**
+     * @param \Illuminate\Support\Collection $rules
+     * @return string[]
+     */
+    private function getPropertyTypes(Collection $rules): array
+    {
+        return $rules
+            ->keys()
+            ->filter(fn(string $rule) => !in_array($rule, static::CONTROL_KEYS, true))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     */
+    private function parseRuleObject(string $property, object $rule): Collection
+    {
+        if (method_exists($rule, '__toString')) {
+            return $this->parseRuleString($property, (string)$rule);
+        }
+
+        return collect(
+            match (true) {
+                ($rule instanceof Password), ($rule instanceof FortifyPassword) => ['string' => null],
+                ($rule instanceof ClosureValidationRule) => ['any' => null],
+                in_array($clazz = get_class($rule), $this->customRules, true) => array_fill_keys(
+                    Arr::wrap($this->customRules[$clazz]),
+                    null
+                ),
+                default => null
+            }
+        );
+    }
+
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     */
+    private function parseRuleString(string $property, string $rule): Collection
+    {
+        return collect(explode(':', $rule, 2))
+            ->mapWithKeys(
+                fn(string $args, int|string $key) => is_int($key)
+                    ? [$this->parseRuleName($property, $args) => null]
+                    : [$this->parseRuleName($property, $key, $args) => $args]
+            );
+    }
+
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     */
+    private function parseRuleName(string $property, string $rule, string $args = null): ?string
+    {
+        return match ($rule) {
+            'nullable', 'sometimes', 'present', 'prohibited', 'required', 'same', 'confirmed' => $rule,
+            'exists', 'unique' => $this->resolveColumn($property, $args),
+            'accepted', 'accepted_if', 'boolean' => 'boolean',
+            'active_url', 'after', 'after_or_equal', 'alpha', 'alpha_dash', 'alpha_num', 'before', 'before_or_equal', 'current_password', 'date', 'date_equals', 'date_format', 'digits', 'digits_between', 'email', 'ends_with', 'ip', 'ipv4', 'ipv6', 'json', 'not_regex', 'password', 'regex', 'starts_with', 'string', 'timezone', 'url', 'uuid' => 'string',
+            'dimensions', 'file', 'image', 'mimetypes', 'mimes' => 'Blob | File',
+            'integer', 'numeric' => 'number',
+            'array' => 'array',
+            default => null
+        };
+    }
+
+    /**
+     * @param string $property
+     * @param string|null $args
+     * @return string|null
+     * @throws \Doctrine\DBAL\Exception
+     */
+    private function resolveColumn(string $property, ?string $args): ?string
+    {
+        $args = explode(',', $args);
+        if (count($args) === 0) {
+            return null;
+        }
+
+        $table = $args[0];
+        $columnName = Arr::get($args, 1) ?? $property;
+
+        /** @var \Illuminate\Database\Connection $connection */
+        $connection = DB::connection();
+
+        $prefix = $connection->getTablePrefix();
+
+        if (!Schema::hasTable("$prefix$table") || !Schema::hasColumn("$prefix$table", $columnName)) {
+            return null;
+        }
+
+        $schemaManager = $connection->getDoctrineSchemaManager();
+        $columns = collect($schemaManager->listTableColumns("$prefix$table"));
+
+        /** @var Column $column */
+        $column = $columns->first(fn(Column $column) => $column->getName() === $columnName);
+
+        return $this->getColumnType($column->getType()->getName());
+    }
+
+    #[Pure] protected function getColumnType(string $type): string|array
+    {
+        return match ($type) {
+            Types::ARRAY, Types::JSON, Types::SIMPLE_ARRAY => [TypeScriptType::array(), TypeScriptType::ANY],
+            Types::ASCII_STRING, Types::BINARY, Types::BLOB, Types::DATE_MUTABLE,
+            Types::DATE_IMMUTABLE, Types::DATEINTERVAL, Types::DATETIME_MUTABLE,
+            Types::DATETIME_IMMUTABLE, Types::DATETIMETZ_MUTABLE, Types::DATETIMETZ_IMMUTABLE,
+            Types::GUID, Types::STRING, Types::TEXT => TypeScriptType::STRING,
+            Types::BIGINT, Types::DECIMAL, Types::FLOAT, Types::INTEGER,
+            Types::SMALLINT, Types::TIME_MUTABLE, Types::TIME_IMMUTABLE => TypeScriptType::NUMBER,
+            Types::BOOLEAN => TypeScriptType::BOOLEAN,
+            default => TypeScriptType::ANY,
+        };
+    }
+
+    private function rulesToStringArray(Collection $rules, int $depth = 0): Collection
+    {
+        /** @var Collection $arrayRules */
+        /** @var Collection $rules */
+        [$arrayRules, $rules] = $rules->partition(
+            fn(array $value) => in_array('array', $value['types'], true) ||
+                str_contains($value['name'], '.')
+        );
+
+        return $rules
+            ->merge($this->mergeArrays($arrayRules, $depth + 1))
+            ->values()
+            ->map(fn(array $value) => strval(app()->make(TypeScriptProperty::class, $value)))
+            ->values();
+    }
+
+    private function mergeArrays(Collection $rules, int $depth): Collection
+    {
+        /** @var Collection $dotRules */
+        /** @var Collection $rules */
+        [$dotRules, $rules] = $rules
+            ->map(function (array $value, string $property) {
+                $value['name'] = $property;
+                $value['types'] = array_values(
+                    array_filter(
+                        $value['types'],
+                        fn(string $type) => $type !== 'array'
+                    )
+                );
+                $value['is_array'] = null;
+                $value['children'] = [];
+
+                return $value;
+            })
+            ->partition(fn(array $value, string $property) => str_contains($property, '.'));
+
+        $rules = $rules->all();
+
+        /** @var string $property */
+        /** @var array $value */
+        foreach ($dotRules as $property => $value) {
+            [$property, $remainder] = explode('.', $property, 2);
+
+            if (!array_key_exists($property, $rules)) {
+                $rules[$property] = [
+                    'name' => $property,
+                    'types' => [],
+                    'optional' => false,
+                    'nullable' => false,
+                    'is_array' => null,
+                    'children' => [],
+                ];
+            }
+
+            $isArray = $remainder === '*' || str_starts_with($remainder, '*.');
+
+            if ($rules[$property]['is_array'] !== null && $rules[$property]['is_array'] !== $isArray) {
+                throw new \RuntimeException('Cannot combine array and object rules for the same property');
+            }
+
+            $rules[$property]['is_array'] = $isArray;
+
+            if ($remainder === '*') {
+                $rules[$property]['types'] = array_merge(
+                    $rules[$property]['types'],
+                    $value['types']
+                );
+
+                continue;
+            }
+
+            if ($isArray) {
+                $remainder = substr($remainder, 2);
+            }
+
+            $rules[$property]['children'][$remainder] = $value;
+        }
+
+        $rules = collect($rules);
+
+        $prefix = str_repeat(" ", 8 + $depth * 4);
+        $endPrefix = substr($prefix, 4);
+
+        return $rules
+            ->map(function (array $value) use ($depth, $prefix, $endPrefix) {
+                $result = Arr::except($value, ['is_array', 'children']);
+
+                if (empty($value['children'])) {
+                    if (empty($result['types'])) {
+                        $result['types'] = ['any'];
+                    } elseif ($value['is_array'] !== null) {
+                        $result['types'] = ['Array<' . implode(' | ', $result['types']) . '>'];
+                    }
+
+                    return $result;
+                }
+
+                /** @var Collection $plainArray */
+                /** @var Collection $children */
+                [$plainArray, $children] = collect($value['children'])
+                    ->partition(fn(array $value) => $value['name'] === '*');
+
+                if ($plainArray->isNotEmpty()) {
+                    $types = implode(' | ', $plainArray->first()['types']) ?: 'any';
+
+                    $result['types'][] = "Array<{$types}>";
+                }
+
+                if ($children->isNotEmpty()) {
+                    $typeObject = $this->rulesToStringArray($children, $depth)
+                        ->map(fn(string $line) => "$prefix$line")
+                        ->join(PHP_EOL);
+
+                    $typeObject = <<< END
+{
+$typeObject
+$endPrefix}
+END;
+
+
+                    if ($value['is_array']) {
+                        $typeObject = "Array<$typeObject>";
+                    }
+
+                    $result['types'][] = $typeObject;
+                }
+
+                return $result;
+            });
+    }
+}

--- a/src/Generators/RequestGenerator.php
+++ b/src/Generators/RequestGenerator.php
@@ -49,7 +49,7 @@ class RequestGenerator extends AbstractGenerator
         }
 
         $rules = $rules
-            ->flatMap(fn(array|string $rules, string $property) => $this->parseRules($property, $rules))
+            ->flatMap(fn (array|string $rules, string $property) => $this->parseRules($property, $rules))
             ->filter();
 
         if ($rules->isEmpty()) {
@@ -91,7 +91,7 @@ class RequestGenerator extends AbstractGenerator
 
         $rules = collect($rules)
             ->values()
-            ->flatMap(fn(string|Rule $rule) => match (true) {
+            ->flatMap(fn (string|Rule $rule) => match (true) {
                 is_object($rule) => $this->parseRuleObject($property, $rule),
                 default => $this->parseRuleString($property, $rule)
             })
@@ -142,7 +142,7 @@ class RequestGenerator extends AbstractGenerator
     {
         return $rules
             ->keys()
-            ->filter(fn(string $rule) => !in_array($rule, static::CONTROL_KEYS, true))
+            ->filter(fn (string $rule) => !in_array($rule, static::CONTROL_KEYS, true))
             ->values()
             ->all();
     }
@@ -153,7 +153,7 @@ class RequestGenerator extends AbstractGenerator
     private function parseRuleObject(string $property, object $rule): Collection
     {
         if (method_exists($rule, '__toString')) {
-            return $this->parseRuleString($property, (string)$rule);
+            return $this->parseRuleString($property, (string) $rule);
         }
 
         return collect(
@@ -176,7 +176,7 @@ class RequestGenerator extends AbstractGenerator
     {
         return collect(explode(':', $rule, 2))
             ->mapWithKeys(
-                fn(string $args, int|string $key) => is_int($key)
+                fn (string $args, int|string $key) => is_int($key)
                     ? [$this->parseRuleName($property, $args) => null]
                     : [$this->parseRuleName($property, $key, $args) => $args]
             );
@@ -228,7 +228,7 @@ class RequestGenerator extends AbstractGenerator
         $columns = collect($schemaManager->listTableColumns("$prefix$table"));
 
         /** @var Column $column */
-        $column = $columns->first(fn(Column $column) => $column->getName() === $columnName);
+        $column = $columns->first(fn (Column $column) => $column->getName() === $columnName);
 
         return $this->getColumnType($column->getType()->getName());
     }
@@ -253,14 +253,14 @@ class RequestGenerator extends AbstractGenerator
         /** @var Collection $arrayRules */
         /** @var Collection $rules */
         [$arrayRules, $rules] = $rules->partition(
-            fn(array $value) => in_array('array', $value['types'], true) ||
+            fn (array $value) => in_array('array', $value['types'], true) ||
                 str_contains($value['name'], '.')
         );
 
         return $rules
             ->merge($this->mergeArrays($arrayRules, $depth + 1))
             ->values()
-            ->map(fn(array $value) => strval(app()->make(TypeScriptProperty::class, $value)))
+            ->map(fn (array $value) => strval(app()->make(TypeScriptProperty::class, $value)))
             ->values();
     }
 
@@ -274,7 +274,7 @@ class RequestGenerator extends AbstractGenerator
                 $value['types'] = array_values(
                     array_filter(
                         $value['types'],
-                        fn(string $type) => $type !== 'array'
+                        fn (string $type) => $type !== 'array'
                     )
                 );
                 $value['is_array'] = null;
@@ -282,7 +282,7 @@ class RequestGenerator extends AbstractGenerator
 
                 return $value;
             })
-            ->partition(fn(array $value, string $property) => str_contains($property, '.'));
+            ->partition(fn (array $value, string $property) => str_contains($property, '.'));
 
         $rules = $rules->all();
 
@@ -348,7 +348,7 @@ class RequestGenerator extends AbstractGenerator
                 /** @var Collection $plainArray */
                 /** @var Collection $children */
                 [$plainArray, $children] = collect($value['children'])
-                    ->partition(fn(array $value) => $value['name'] === '*');
+                    ->partition(fn (array $value) => $value['name'] === '*');
 
                 if ($plainArray->isNotEmpty()) {
                     $types = implode(' | ', $plainArray->first()['types']) ?: 'any';
@@ -358,7 +358,7 @@ class RequestGenerator extends AbstractGenerator
 
                 if ($children->isNotEmpty()) {
                     $typeObject = $this->rulesToStringArray($children, $depth)
-                        ->map(fn(string $line) => "$prefix$line")
+                        ->map(fn (string $line) => "$prefix$line")
                         ->join(PHP_EOL);
 
                     $typeObject = <<< END

--- a/src/TypeScriptGenerator.php
+++ b/src/TypeScriptGenerator.php
@@ -13,7 +13,7 @@ class TypeScriptGenerator
 {
     public function __construct(
         public array $generators,
-        public array $paths,
+        public array $paths = [],
         public string $output,
         public bool $autoloadDev
     )

--- a/src/TypeScriptGenerator.php
+++ b/src/TypeScriptGenerator.php
@@ -16,24 +16,24 @@ class TypeScriptGenerator
         public array $paths = [],
         public string $output,
         public bool $autoloadDev
-    )
-    {
+    ) {
     }
 
     public function execute()
     {
         $types = $this->phpClasses()
-            ->groupBy(fn(ReflectionClass $reflection) => $reflection->getNamespaceName())
-            ->map(fn(Collection $reflections, string $namespace) => $this->makeNamespace($namespace, $reflections))
-            ->reject(fn(string $namespaceDefinition) => empty($namespaceDefinition))
-            ->prepend(<<<END
-/**
- * This file is auto generated using 'php artisan typescript-generate'
- *
- * Changes to this file will be lost when the command is run again
- */
+            ->groupBy(fn (ReflectionClass $reflection) => $reflection->getNamespaceName())
+            ->map(fn (Collection $reflections, string $namespace) => $this->makeNamespace($namespace, $reflections))
+            ->reject(fn (string $namespaceDefinition) => empty($namespaceDefinition))
+            ->prepend(
+                <<<END
+                /**
+                 * This file is auto generated using 'php artisan typescript-generate'
+                 *
+                 * Changes to this file will be lost when the command is run again
+                 */
 
-END
+                END
             )
             ->join(PHP_EOL);
 
@@ -42,7 +42,7 @@ END
 
     protected function makeNamespace(string $namespace, Collection $reflections): string
     {
-        return $reflections->map(fn(ReflectionClass $reflection) => $this->makeInterface($reflection))
+        return $reflections->map(fn (ReflectionClass $reflection) => $this->makeInterface($reflection))
             ->whereNotNull()
             ->whenNotEmpty(function (Collection $definitions) use ($namespace) {
                 $tsNamespace = str_replace('\\', '.', $namespace);
@@ -55,7 +55,7 @@ END
     protected function makeInterface(ReflectionClass $reflection): ?string
     {
         $generator = collect($this->generators)
-            ->filter(fn(string $generator, string $baseClass) => $reflection->isSubclassOf($baseClass))
+            ->filter(fn (string $generator, string $baseClass) => $reflection->isSubclassOf($baseClass))
             ->values()
             ->first();
 
@@ -81,10 +81,10 @@ END
                 return collect((new Finder)->in($path)->name('*.php')->files())
                     ->map(function (SplFileInfo $file) use ($path, $namespace) {
                         return $namespace . str_replace(
-                                ['/', '.php'],
-                                ['\\', ''],
-                                Str::after($file->getRealPath(), realpath($path) . DIRECTORY_SEPARATOR)
-                            );
+                            ['/', '.php'],
+                            ['\\', ''],
+                            Str::after($file->getRealPath(), realpath($path) . DIRECTORY_SEPARATOR)
+                        );
                     })
                     ->filter(function (string $className) {
                         try {
@@ -95,8 +95,8 @@ END
                             return false;
                         }
                     })
-                    ->map(fn(string $className) => new ReflectionClass($className))
-                    ->reject(fn(ReflectionClass $reflection) => $reflection->isAbstract())
+                    ->map(fn (string $className) => new ReflectionClass($className))
+                    ->reject(fn (ReflectionClass $reflection) => $reflection->isAbstract())
                     ->values();
             });
     }

--- a/src/TypeScriptGenerator.php
+++ b/src/TypeScriptGenerator.php
@@ -28,7 +28,7 @@ class TypeScriptGenerator
             ->prepend(
                 <<<END
                 /**
-                 * This file is auto generated using 'php artisan typescript-generate'
+                 * This file is auto generated using 'php artisan typescript:generate'
                  *
                  * Changes to this file will be lost when the command is run again
                  */

--- a/src/TypeScriptGenerator.php
+++ b/src/TypeScriptGenerator.php
@@ -13,9 +13,9 @@ class TypeScriptGenerator
 {
     public function __construct(
         public array $generators,
-        public array $paths = [],
         public string $output,
-        public bool $autoloadDev
+        public bool $autoloadDev,
+        public array $paths = []
     ) {
     }
 


### PR DESCRIPTION
- Add support for custom paths (to load relevant items from 'vendor' folder)
- Use explicit config values (with fallback) instead of spread operator in command
- Add the "generate" command to Generator Contract (since this is what's actually called from the TypeScriptGenerator class)
- Cleanup of generated code (additional white space, information message, etc)
- A generator for FormRequest classes
- **TODO**: Tests for request generator