### PR TITLE
Fix return type with prefix "?"

### DIFF
--- a/src/Definitions/TypeScriptType.php
+++ b/src/Definitions/TypeScriptType.php
@@ -23,6 +23,10 @@ class TypeScriptType
         $types = $method->getReturnType() instanceof ReflectionUnionType
             ? $method->getReturnType()->getTypes()
             : (string) $method->getReturnType();
+        
+        if (is_string($types) and strpos($types, '?') !== false) {
+            $types = [str_replace('?', '', $types), 'null'];
+        }
 
         return collect($types)
             ->map(function (string $type) {

--- a/src/Definitions/TypeScriptType.php
+++ b/src/Definitions/TypeScriptType.php
@@ -23,9 +23,12 @@ class TypeScriptType
         $types = $method->getReturnType() instanceof ReflectionUnionType
             ? $method->getReturnType()->getTypes()
             : (string) $method->getReturnType();
-        
-        if (is_string($types) and strpos($types, '?') !== false) {
-            $types = [str_replace('?', '', $types), 'null'];
+
+        if (is_string($types) && strpos($types, '?') !== false) {
+            $types = [
+                str_replace('?', '', $types),
+                self::NULL
+            ];
         }
 
         return collect($types)


### PR DESCRIPTION
Fix return types prefixed with "?", example: "?string" or "string|null" in accessor methods.