### PR TITLE
fix: Generate relation names in snake_case

### DIFF
--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -114,7 +114,7 @@ class ModelGenerator extends AbstractGenerator
             })
             ->map(function (ReflectionMethod $method) {
                 return (string) new TypeScriptProperty(
-                    name: $method->getName(),
+                    name: Str::snake($method->getName()),
                     types: $this->getRelationType($method),
                     optional: true,
                     nullable: true

--- a/src/TypeScriptGenerator.php
+++ b/src/TypeScriptGenerator.php
@@ -68,7 +68,7 @@ class TypeScriptGenerator
 
     protected function phpClasses(): Collection
     {
-        $composer = json_decode(file_get_contents(realpath('composer.json')));
+        $composer = json_decode(file_get_contents(__DIR__ . './../composer.json'));
 
         return collect($composer->autoload->{'psr-4'})
             ->when($this->autoloadDev, function (Collection $paths) use ($composer) {

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -22,9 +22,12 @@ class GeneratorTest extends TestCase
 
         $generator->execute();
 
-        assertFileExists($output);
+        $this->assertFileExists($output);
 
-        assertEquals(3, substr_count(file_get_contents($output), 'interface'));
+        $result = file_get_contents($output);
+
+        $this->assertEquals(3, substr_count($result, 'interface'));
+        $this->assertTrue(strpos($result, 'sub_category?: Based.TypeScript.Tests.Models.Category | null;') > -1);
 
         unlink($output);
     }

--- a/tests/Models/Product.php
+++ b/tests/Models/Product.php
@@ -13,6 +13,11 @@ class Product extends Model
         return $this->belongsTo(Category::class);
     }
 
+    public function subCategory(): BelongsTo
+    {
+        return $this->belongsTo(Category::class);
+    }
+
     public function features(): HasMany
     {
         return $this->hasMany(Feature::class);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -41,6 +41,7 @@ class TestCase extends Orchestra
         Schema::create('products', function (Blueprint $table) {
             $table->id();
             $table->foreignId('category_id');
+            $table->foreignId('sub_category_id')->constrained('categories');
             $table->string('name');
             $table->decimal('price');
             $table->json('data')->nullable();


### PR DESCRIPTION
By default, Laravel uses snake_case names for multi-word relations. The PR fixes that and adds an assertion.
It also fixes `composer.json` loading that also works in a debugger environment or when tests is run not from project root (for example running using IDE)