### PR TITLE
Workaround for lack of enum support by DBAL

### DIFF
--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
 use ReflectionClass;
 use ReflectionMethod;
 use Throwable;
@@ -28,6 +29,12 @@ class ModelGenerator extends AbstractGenerator
     protected Model $model;
     /** @var Collection<Column> */
     protected Collection $columns;
+
+    public function __construct()
+    {
+        // Enums aren't supported by DBAL, so map enum columns to string.
+        DB::getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+    }
 
     public function getDefinition(): ?string
     {


### PR DESCRIPTION
Unfortunately this package does not work if the database has enum columns. DBAL does not support enum column types. In this PR the enum columns are mapped to strings, so we can still use the package when we have enum columns in our database. The TypeScript models will have a string type instead of an enum. Maybe not the best solution to this problem, but maybe it helps others for the time being.