### PR TITLE
feat: add support for Enum casts, Attribute-based accessors, Output Modifiers

### DIFF
--- a/config/typescript.php
+++ b/config/typescript.php
@@ -1,11 +1,18 @@
 <?php
 
+use Based\TypeScript\Generators\EnumCastGenerator;
 use Based\TypeScript\Generators\ModelGenerator;
 use Illuminate\Database\Eloquent\Model;
+use Based\TypeScript\Contracts\ModelEnum;
 
 return [
     'generators' => [
         Model::class => ModelGenerator::class,
+        /**
+         * To enable Enum cast codegen, 
+         * Enums must implement the Based\TypeScript\Contracts\ModelEnum interface.
+         */
+        // ModelEnum::class => EnumCastGenerator::class,
     ],
 
     'paths' => [
@@ -20,4 +27,28 @@ return [
     'output' => resource_path('js/models.d.ts'),
 
     'autoloadDev' => false,
+
+    /**
+     * Generate a TypeScript enum (that will be available at runtime) for every model cast.
+     */
+    'runtimeEnums' => true,
+
+    /**
+     * File to write the generated TS enums to.
+     */
+    'runtimeEnumsOutput' => resource_path('js/model-enums.ts'),
+
+    /**
+     * Modifiers can alter the generated declaration content before writing it to the file.
+     * Modifiers must implement Utils\TypeScript\OutputModifiers\OutputModifier contract.
+     */
+    'outputModifiers' => [
+    ],
+
+    /**
+     * Enum Modifiers can alter the generated Enums declaration before merging it in the global declaration content.
+     * Enum Modifiers must implement Utils\TypeScript\OutputModifiers\OutputModifier contract.
+     */
+    'runtimeEnumsOutputModifiers' => [
+    ],
 ];

--- a/src/Commands/TypeScriptGenerateCommand.php
+++ b/src/Commands/TypeScriptGenerateCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Based\TypeScript\Commands;
 
 use Based\TypeScript\TypeScriptGenerator;

--- a/src/Contracts/Generator.php
+++ b/src/Contracts/Generator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Based\TypeScript\Contracts;
 
 use ReflectionClass;

--- a/src/Contracts/ModelEnum.php
+++ b/src/Contracts/ModelEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Based\TypeScript\Contracts;
+
+interface ModelEnum
+{
+}

--- a/src/Contracts/OutputModifier.php
+++ b/src/Contracts/OutputModifier.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Based\TypeScript\Contracts;
+
+interface OutputModifier
+{
+    /**
+     * Alter types declaration before writing it.
+     *
+     * @param string $content
+     *
+     * @return string
+     */
+    public function modify(string $content): string;
+}

--- a/src/Definitions/TypeScriptProperty.php
+++ b/src/Definitions/TypeScriptProperty.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Based\TypeScript\Definitions;
 
 use Illuminate\Support\Collection;

--- a/src/Definitions/TypeScriptType.php
+++ b/src/Definitions/TypeScriptType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Based\TypeScript\Definitions;
 
 use ReflectionMethod;

--- a/src/Generators/AbstractGenerator.php
+++ b/src/Generators/AbstractGenerator.php
@@ -6,13 +6,12 @@ namespace Based\TypeScript\Generators;
 
 use Based\TypeScript\Contracts\Generator;
 use ReflectionClass;
-use ReflectionEnum;
 
 abstract class AbstractGenerator implements Generator
 {
     protected ReflectionClass $reflection;
 
-    public function generate(ReflectionClass|ReflectionEnum $reflection): ?string
+    public function generate(ReflectionClass $reflection): ?string
     {
         $this->reflection = $reflection;
         $this->boot();

--- a/src/Generators/AbstractGenerator.php
+++ b/src/Generators/AbstractGenerator.php
@@ -1,15 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Based\TypeScript\Generators;
 
 use Based\TypeScript\Contracts\Generator;
 use ReflectionClass;
+use ReflectionEnum;
 
 abstract class AbstractGenerator implements Generator
 {
     protected ReflectionClass $reflection;
 
-    public function generate(ReflectionClass $reflection): ?string
+    public function generate(ReflectionClass|ReflectionEnum $reflection): ?string
     {
         $this->reflection = $reflection;
         $this->boot();

--- a/src/Generators/EnumCastGenerator.php
+++ b/src/Generators/EnumCastGenerator.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Based\TypeScript\Generators;
+
+use Based\TypeScript\Contracts\Generator;
+use Based\TypeScript\Generators\AbstractGenerator;
+use ReflectionClass;
+use ReflectionEnum;
+use ReflectionEnumUnitCase;
+use ReflectionEnumBackedCase;
+
+class EnumCastGenerator
+{
+    protected ReflectionEnum $reflectionEnum;
+
+    public function getDefinition(): ?string
+    {
+        return collect($this->reflectionEnum->getCases())
+            ->map(function (ReflectionEnumUnitCase|ReflectionEnumBackedCase $case) {
+                if ($case instanceof ReflectionEnumBackedCase) {
+                    return sprintf("%s = '%s',", $case->getName(), $case->getValue()->name);
+                } else {
+                    return $case->getName() . ',';
+                }
+            })
+            ->filter(fn (string $part) => !empty($part))
+            ->join(PHP_EOL . '    ');
+    }
+
+    public function generate(ReflectionEnum $reflection): ?string
+    {
+        $this->reflectionEnum = $reflection;
+        
+        if (empty(trim($definition = $this->getDefinition()))) {
+            return "export enum {$this->tsEnumName()}Enum {}" . PHP_EOL . PHP_EOL .
+                "export const {$this->tsEnumName()}EnumArray {}" . PHP_EOL;
+        }
+
+        return <<<TS
+        export enum {$this->tsEnumName()}Enum {
+            $definition
+        }
+        
+        export const {$this->tsEnumName()}EnumArray = Object.values({$this->tsEnumName()}Enum)
+        
+        TS;
+    }
+
+    protected function tsEnumName(): string
+    {
+        return str_replace('\\', '.', $this->reflectionEnum->getShortName());
+    }
+}

--- a/src/Generators/RequestGenerator.php
+++ b/src/Generators/RequestGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Based\TypeScript\Generators;
 
 use Based\TypeScript\Definitions\TypeScriptProperty;

--- a/src/TypeScriptGenerator.php
+++ b/src/TypeScriptGenerator.php
@@ -1,13 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Based\TypeScript;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use ReflectionClass;
 use ReflectionException;
+use ReflectionEnum;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;
+use Based\TypeScript\Contracts\OutputModifier;
 
 class TypeScriptGenerator
 {
@@ -15,7 +19,11 @@ class TypeScriptGenerator
         public array $generators,
         public string $output,
         public bool $autoloadDev,
-        public array $paths = []
+        public array $paths = [],
+        public bool $runtimeEnums = false,
+        public ?string $runtimeEnumsOutput = null,
+        public array $outputModifiers = [],
+        public array $runtimeEnumsOutputModifiers = []
     ) {
     }
 
@@ -38,6 +46,47 @@ class TypeScriptGenerator
             ->join(PHP_EOL);
 
         file_put_contents($this->output, $types);
+
+        // Get previously generated types for classes.
+        $types = file_get_contents($this->output);
+
+        // Alter generated content using OutputModifiers.
+        if (!empty(($this->outputModifiers))) {
+            collect($this->outputModifiers)
+                ->map(fn (string $modifierClass) => new $modifierClass())
+                ->each(function (OutputModifier $modifier) use (&$types) {
+                    $types = $modifier->modify($types);
+                });
+        }
+        file_put_contents($this->output, $types);
+
+        if ($this->runtimeEnums) {
+            $enumTypes = $this->phpEnums()
+                ->groupBy(fn(ReflectionEnum $reflection) => $reflection->getNamespaceName())
+                ->map(fn(Collection $reflections, string $namespace) => $this->makeRuntimeEnums($namespace, $reflections))
+                ->reject(fn(string $namespaceDefinition) => empty($namespaceDefinition))
+                ->prepend(
+                    <<<END
+                /**
+                 * This file is auto generated using 'php artisan typescript:generate'
+                 *
+                 * Changes to this file will be lost when the command is run again
+                 */
+
+                END
+                )
+                ->join(PHP_EOL);
+
+            // Alter generated content using Enum OutputModifiers.
+            if (!empty(($this->runtimeEnumsOutputModifiers))) {
+                collect($this->runtimeEnumsOutputModifiers)
+                    ->map(fn (string $modifierClass) => new $modifierClass())
+                    ->each(function (OutputModifier $modifier) use (&$enumTypes) {
+                        $enumTypes = $modifier->modify($enumTypes);
+                    });
+            }
+            file_put_contents($this->runtimeEnumsOutput, $enumTypes);
+        }
     }
 
     protected function makeNamespace(string $namespace, Collection $reflections): string
@@ -63,6 +112,28 @@ class TypeScriptGenerator
             return null;
         }
 
+        return (new $generator)->generate($reflection);
+    }
+
+    protected function makeRuntimeEnums(string $namespace, Collection $reflections): string
+    {
+        return $reflections->map(fn(ReflectionEnum $reflection) => $this->makeEnum($reflection))
+            ->whereNotNull()
+            ->join(PHP_EOL);
+    }
+
+    protected function makeEnum(ReflectionEnum $reflection): ?string
+    {
+        $generator = collect($this->generators)
+            ->filter(
+                fn(string $generator, string $interface) => interface_exists($interface) &&
+                    $reflection->implementsInterface($interface)
+            )
+            ->values()
+            ->first();
+        if (!$generator) {
+            return null;
+        }
         return (new $generator)->generate($reflection);
     }
 
@@ -96,7 +167,33 @@ class TypeScriptGenerator
                         }
                     })
                     ->map(fn (string $className) => new ReflectionClass($className))
-                    ->reject(fn (ReflectionClass $reflection) => $reflection->isAbstract())
+                    ->reject(fn (ReflectionClass $reflection) => $reflection->isAbstract() || $reflection->isEnum())
+                    ->values();
+            });
+    }
+
+    protected function phpEnums(): Collection
+    {
+        $composer = json_decode(file_get_contents(realpath('composer.json')));
+
+        return collect($composer->autoload->{'psr-4'})
+            ->when($this->autoloadDev, function (Collection $paths) use ($composer) {
+                return $paths->merge(
+                    collect($composer->{'autoload-dev'}?->{'psr-4'})
+                );
+            })
+            ->merge($this->paths)
+            ->flatMap(function (string $path, string $namespace) {
+                return collect((new Finder)->in($path)->name('*.php')->files())
+                    ->map(function (\SplFileInfo $file) use ($path, $namespace) {
+                        return $namespace . str_replace(
+                                ['/', '.php'],
+                                ['\\', ''],
+                                Str::after($file->getRealPath(), realpath($path) . DIRECTORY_SEPARATOR)
+                            );
+                    })
+                    ->filter(fn(string $enumName) => enum_exists($enumName))
+                    ->map(fn(string $enumName) => new ReflectionEnum($enumName))
                     ->values();
             });
     }

--- a/src/TypeScriptServiceProvider.php
+++ b/src/TypeScriptServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Based\TypeScript;
 
 use Based\TypeScript\Commands\TypeScriptGenerateCommand;


### PR DESCRIPTION
This is an early PR to open a discussion on the following improvements (see #3):  

- **Generate types for Eloquent Model "enum" casts** 
- **Generate TS `enum`s for these Enums so we can use those during runtime (Enum must implement a new `ModelEnum` interface to be picked)**    
- **Generate properties for the new [`Attribute`-based accessors](https://laravel.com/docs/9.x/eloquent-mutators#defining-an-accessor)**
- **Introduce the concept of `OutputModifiers` to create a pipeline of modifiers that will change the generated content before its written to a file**  
- Add strict types declaration  

What must be done before merging it:  
- [ ] Write tests   
- [ ] Update README  
- [ ] ?

What would be nice to have, but can totally be done later:  
- [ ] Reduce code duplication (`phpClasses()` / `phpEnums`)  
- [ ] Maybe refactor `AbstractGenerator` so it's less coupled to classes and also allows enums  
- [ ] Don't hardcode the `Enum` suffix, make it configurable  
- [ ] Don't hardcode the `EnumArray` suffix, make it configurable  

This is a "quick and dirty" implementation that was written on the go for a project I'm working on, but it works quite well - right now we can use the generated typings as-is without modifying those manually.  

It *does* need some polishing before merging it.  

Also I've copied the files from what I've written by hand so there may be a few typos, missing `use` statements...  
I just wanted to publish it as soon as possible to collect feedback, and take some time the next weekend to polish it accordingly.  

Thanks in advance for your feedback :)