### PR TITLE
Make ModelGenerator account for hidden fields

### DIFF
--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -60,7 +60,7 @@ class ModelGenerator extends AbstractGenerator
             $this->model->getConnection()
                 ->getDoctrineSchemaManager()
                 ->listTableColumns($this->model->getConnection()->getTablePrefix() . $this->model->getTable())
-        );
+        )->filter(fn ($prop, $key) => !in_array($key, $this->model->getHidden()));
     }
 
     protected function getProperties(): string


### PR DESCRIPTION
Make ModelGenerator filter out columns that have been hidden from the serialized representation of the Model (see: https://laravel.com/docs/9.x/eloquent-serialization#hiding-attributes-from-json).

The hidden attribute is commonly used with fields like `password` or `remember_token`.

Without filtering the types generated for a model misrepresent what is commonly sent by a server for this model:
```json
{
  "id": 1,
  "name": "Test User",
  "email": "user@user.com",
  "email_verified_at": "2022-06-29T14:51:15.000000Z",
  "created_at": "2022-06-29T09:18:09.000000Z",
  "updated_at": "2022-06-29T09:18:09.000000Z"
}
```
for a generated type
```ts
export interface User {
    id: number;
    name: string;
    email: string;
    email_verified_at: string | null;
    created_at: string | null;
    updated_at: string | null;
}
```

instead of (without filtering hidden fields)

```ts
export interface User {
    id: number;
    name: string;
    email: string;
    password: string ;
    remember_token: string ;
    email_verified_at: string | null;
    created_at: string | null;
    updated_at: string | null;
}
```

