### PR TITLE
Sort the generated classes by name

### DIFF
--- a/src/TypeScriptGenerator.php
+++ b/src/TypeScriptGenerator.php
@@ -22,6 +22,7 @@ class TypeScriptGenerator
     public function execute()
     {
         $types = $this->phpClasses()
+            ->sortBy(fn (ReflectionClass $reflection) => $reflection->getName())
             ->groupBy(fn (ReflectionClass $reflection) => $reflection->getNamespaceName())
             ->map(fn (Collection $reflections, string $namespace) => $this->makeNamespace($namespace, $reflections))
             ->reject(fn (string $namespaceDefinition) => empty($namespaceDefinition))


### PR DESCRIPTION
The classes that are generated are done using symfony's finder class, which can return files in any order returned by the filesystem.

This means that running the `typescript:generate` command can generate incredibly noisy diffs - whereas at least if it's sorted then the diffs should be slightly more sensible.