### PR TITLE
fix(model-generator): prevent duplicate identifier issues

### DIFF
--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -77,6 +77,11 @@ class ModelGenerator extends AbstractGenerator
 
     protected function getAccessors(): string
     {
+        $relationsToSkip =  $this->getRelationMethods()
+            ->map(function (ReflectionMethod $method) {
+                return Str::snake($method->getName());
+            });
+
         return $this->getMethods()
             ->filter(fn (ReflectionMethod $method) => Str::startsWith($method->getName(), 'get'))
             ->filter(fn (ReflectionMethod $method) => Str::endsWith($method->getName(), 'Attribute'))
@@ -89,6 +94,9 @@ class ModelGenerator extends AbstractGenerator
             })
             ->reject(function (ReflectionMethod $method, string $property) {
                 return $this->columns->contains(fn (Column $column) => $column->getName() == $property);
+            })
+            ->reject(function (ReflectionMethod $method, string $property) use ($relationsToSkip) {
+                return $relationsToSkip->contains($property);
             })
             ->map(function (ReflectionMethod $method, string $property) {
                 return (string) new TypeScriptProperty(


### PR DESCRIPTION
If you have a get***Attribute accessor method with the same name as a db relation, it would get added to the ts file twice.
This version gets the relations real quick and skips the accessors if it already found it.